### PR TITLE
Fix build failures

### DIFF
--- a/experimental/iree/compile_workloads.py
+++ b/experimental/iree/compile_workloads.py
@@ -67,7 +67,7 @@ COMPILE_FLAGS_PER_TARGET = {
     ],
     "pixel-8-pro": [
         "--iree-llvmcpu-target-triple=aarch64-none-linux-android34",
-        "--iree-llvmcpu-target-cpu-features=+v9a,+fullfp16,fp-armv8,+neon,+aes,+sha2,+crc,+lse,+rdm,+complxnum,+rcpc,+sha3,+sm4,+dotprod,+fp16fml,+dit,+flagm,+ssbs,+sb,+sve2-aes,+sve2-bitperm,+sve2-sha3,+sve2-sm4,+altnzcv,+fptoint,+bf16,+i8mm,+bti,+mte,+pauth,+perfmon,+predres,+spe,+ras"
+        "--iree-llvmcpu-target-cpu-features=+v9.2a,+fullfp16,+fp-armv8,+neon,+aes,+sha2,+crc,+lse,+rdm,+complxnum,+rcpc,+sha3,+sm4,+dotprod,+fp16fml,+dit,+flagm,+ssbs,+sb,+sve2-aes,+sve2-bitperm,+sve2-sha3,+sve2-sm4,+altnzcv,+fptoint,+bf16,+i8mm,+bti,+mte,+pauth,+perfmon,+predres,+spe,+ras"
     ],
 }
 

--- a/experimental/tflite/build_tflite.sh
+++ b/experimental/tflite/build_tflite.sh
@@ -41,7 +41,9 @@ pushd tensorflow
 # Log the git version of Tensorflow repo.
 git log --oneline --graph --max-count=1
 
-bazel build -c opt --define xnnpack_use_latest_ops=true //tensorflow/lite/tools/benchmark:benchmark_model
+# Disable avx512fp16 on build servers due to a gcc compiler error:
+#   gcc: error: unrecognized command-line option '-mavx512fp16'
+bazel build -c opt --define xnnpack_use_latest_ops=true --define xnn_enable_avx512fp16=false //tensorflow/lite/tools/benchmark:benchmark_model
 cp "$(realpath bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model)" "${X86_OUTPUT_DIR}/"
 
 # The compiler flags used here were retrieved by running ./configure in the root Tensorflow repo.


### PR DESCRIPTION
Replaces +v9a with +v9.2a CPU feature to fix IREE build failure:
```
error: 'llvm.call' op operand type mismatch for operand 0: '!llvm.struct<(ptr, ptr, i64)>' != '!llvm.ptr'
note: called from stablehlo.mlir:529:11:
note: see current operation: %120 = "llvm.call"(%34, %76, %7, %41, %84, %7, %48, %94, %7, %12, %12, %11, %10, %10, %9, %8, %96) <{CConv = #llvm.cconv<ccc>, callee = @iree_uk_mmt4d, fastmathFlags = #llvm.fastmath<none>}> : (!llvm.struct<(ptr, ptr, i64)>, i64, i64, !llvm.struct<(ptr, ptr, i64)>, i64, i64, !llvm.struct<(ptr, ptr, i64)>, i64, i64, i64, i64, i64, i32, i32, i32, i32, !llvm.ptr) -> i32
/tmp/jax_models_0.4.30_1719201699/T5_LARGE_FP32_JAX_512XI32_BATCH1/stablehlo.mlir:529:11: error: failed to run translation of source executable to target executable for backend #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu = "generic", cpu_features = "+v9a,+fullfp16,+fp-armv8,+neon,+aes,+sha2,+crc,+lse,+rdm,+complxnum,+rcpc,+sha3,+sm4,+dotprod,+fp16fml,+dit,+flagm,+ssbs,+sb,+sve2-aes,+sve2-bitperm,+sve2-sha3,+sve2-sm4,+altnzcv,+fptoint,+bf16,+i8mm,+bti,+mte,+pauth,+perfmon,+predres,+spe,+ras,+reserve-x18", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32", debug_symbols = false, native_vector_size = 16 : i64, target_triple = "aarch64-unknown-unknown-eabi-elf", ukernels = "all"}>
```

Also disables avx512fp16 in TFLite due to this build error:

```
gcc: error: unrecognized command-line option '-mavx512fp16'
```